### PR TITLE
Filter out invalid questions into an error file

### DIFF
--- a/experiments/opencog/question2atomese/README.md
+++ b/experiments/opencog/question2atomese/README.md
@@ -203,7 +203,7 @@ optional arguments:
 
 Run question2atomese app:
 ```
-./question2atomese.sh -i questions.txt -o parsed_questions.txt -a atomspace.scm -e error_questions.txt
+./question2atomese.sh -i questions.txt -o parsed_questions.txt -a atomspace.scm
 ```
 
 question2atomese usage:
@@ -214,7 +214,6 @@ usage: QuestionToOpencogApp
                         questions
  -i,--input <arg>       input filename, stdin if not provided
  -o,--output <arg>      output filename, stdout if not provided
- -e,--error  <arg>      error filename (questions which were not able to parse), stderr if not provided
  ```
 
 ## Sort question types by frequency

--- a/experiments/opencog/question2atomese/README.md
+++ b/experiments/opencog/question2atomese/README.md
@@ -203,7 +203,7 @@ optional arguments:
 
 Run question2atomese app:
 ```
-./question2atomese.sh -i questions.txt -o parsed_questions.txt -a atomspace.scm
+./question2atomese.sh -i questions.txt -o parsed_questions.txt -a atomspace.scm -e error_questions.txt
 ```
 
 question2atomese usage:
@@ -214,6 +214,7 @@ usage: QuestionToOpencogApp
                         questions
  -i,--input <arg>       input filename, stdin if not provided
  -o,--output <arg>      output filename, stdout if not provided
+ -e,--error  <arg>      error filename (questions which were not able to parse), stderr if not provided
  ```
 
 ## Sort question types by frequency

--- a/experiments/opencog/question2atomese/pom.xml
+++ b/experiments/opencog/question2atomese/pom.xml
@@ -11,8 +11,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/experiments/opencog/question2atomese/pom.xml
+++ b/experiments/opencog/question2atomese/pom.xml
@@ -11,8 +11,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.9</maven.compiler.source>
+        <maven.compiler.target>1.9</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/experiments/opencog/question2atomese/pom.xml
+++ b/experiments/opencog/question2atomese/pom.xml
@@ -91,8 +91,15 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.9</version>
+                <configuration>
+                    <argLine>-Xmx256M</argLine>
+                </configuration>
+            </plugin>
         </plugins>
-
     </build>
 
 </project>

--- a/experiments/opencog/question2atomese/src/main/java/org/opencog/vqa/QuestionRecord.java
+++ b/experiments/opencog/question2atomese/src/main/java/org/opencog/vqa/QuestionRecord.java
@@ -2,6 +2,7 @@ package org.opencog.vqa;
 
 import lombok.Builder;
 import lombok.ToString;
+import org.opencog.vqa.relex.RelexFormula;
 
 /**
  * Record class keeps information about one question and able to serialize/deserialize it as 
@@ -20,6 +21,7 @@ class QuestionRecord {
     private final String answer;
     private final String shortFormula;
     private final String fullFormula;
+    private final String formulaInvalidKeys;
 
     public String getQuestionType() {
         return questionType;
@@ -36,6 +38,8 @@ class QuestionRecord {
     public static QuestionRecord load(String string) {
         String[] fields = string.split(FIELD_DELIMITER);
 
+        boolean isValid = isFormulaValid(fields);
+
         QuestionRecordBuilder builder = QuestionRecord.builder();
         
         builder
@@ -44,20 +48,32 @@ class QuestionRecord {
             .question(fields[2])
             .imageId(fields[3])
             .answer(fields[4])
-            .shortFormula(fields.length > 5 ? fields[5] : "")
-            .fullFormula(fields.length > 6 ? fields[6] : "");
+            .shortFormula(isValid && fields.length > 5 ? fields[5] : "")
+            .fullFormula(isValid && fields.length > 6 ? fields[6] : "")
+            .formulaInvalidKeys(isValid ? "" : fields[5]);
             
         return builder.build();
     }
 
-    public String save() {
-        return questionId 
-                + FIELD_DELIMITER + questionType 
-                + FIELD_DELIMITER + question 
+    public String save()
+    {
+
+        return questionId
+                + FIELD_DELIMITER + questionType
+                + FIELD_DELIMITER + question
                 + FIELD_DELIMITER + imageId
                 + FIELD_DELIMITER + answer
-                + FIELD_DELIMITER + shortFormula
-                + FIELD_DELIMITER + fullFormula;
+                + (formulaInvalidKeys.isEmpty()
+                        ? FIELD_DELIMITER + shortFormula
+                        + FIELD_DELIMITER + fullFormula
+                        : FIELD_DELIMITER + formulaInvalidKeys);
+    }
+
+    private static boolean isFormulaValid(String[] fields) {
+
+        return fields.length <= 5 ||
+                !fields[5].contains(RelexFormula.INVALID_KEY_SKIPPED)
+                        && !fields[5].contains(RelexFormula.INVALID_KEY_VIOLATION);
     }
 
 }

--- a/experiments/opencog/question2atomese/src/main/java/org/opencog/vqa/QuestionToOpencogApp.java
+++ b/experiments/opencog/question2atomese/src/main/java/org/opencog/vqa/QuestionToOpencogApp.java
@@ -12,7 +12,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintWriter;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -38,21 +37,25 @@ public class QuestionToOpencogApp {
 
     private static final String OPTION_INPUT = "input";
     private static final String OPTION_OUTPUT = "output";
+    private static final String OPTION_ERROR_OUTPUT = "error";
     private static final String OPTION_ATOMSPACE = "atomspace";
     
     private final BufferedReader bufferedReader;
     private final PrintWriter printWriter;
+    private final PrintWriter errorPrintWriter;
     private final PrintWriter atomspaceWriter;
-    
+
     private final QuestionToOpencogConverter questionToOpencogConverter;
     private final PhraseToWordsConverter phraseToWordsConverter;
 
     @VisibleForTesting
     QuestionToOpencogApp(InputStream inputStream,
             OutputStream outputStream,
+            OutputStream errorOutputStream,
             Optional<OutputStream> atomspaceWriter) {
         this.bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
         this.printWriter = new PrintWriter(outputStream);
+        this.errorPrintWriter = new PrintWriter(errorOutputStream);
         if (atomspaceWriter.isPresent()) {
             this.atomspaceWriter = new PrintWriter(atomspaceWriter.get());
         } else {
@@ -66,10 +69,12 @@ public class QuestionToOpencogApp {
         Options options = new Options();
         InputStream inputStream = null;
         OutputStream outputStream = null;
+        OutputStream errorOutputStream = null;
         OutputStream atomspaceStream = null;
         try {
             options.addOption("i", OPTION_INPUT, true, "input filename, stdin if not provided");
             options.addOption("o", OPTION_OUTPUT, true, "output filename, stdout if not provided");
+            options.addOption("e", OPTION_ERROR_OUTPUT, true, "error output filename, stderr if not provided");
             options.addOption("a", OPTION_ATOMSPACE, true, "filename for atomspace which is calculated from questions");
             
             CommandLineParser argsParser = new DefaultParser();
@@ -81,10 +86,16 @@ public class QuestionToOpencogApp {
             outputStream = commandLine.hasOption(OPTION_OUTPUT) 
                     ? new FileOutputStream(commandLine.getOptionValue(OPTION_OUTPUT))
                     : System.out;
+
+
+            errorOutputStream = commandLine.hasOption(OPTION_ERROR_OUTPUT)
+                    ? new FileOutputStream(commandLine.getOptionValue(OPTION_ERROR_OUTPUT))
+                    : System.err;
             atomspaceStream = commandLine.hasOption(OPTION_ATOMSPACE)
                     ? new FileOutputStream(commandLine.getOptionValue(OPTION_ATOMSPACE))
                     : null;
-            new QuestionToOpencogApp(inputStream, outputStream, Optional.ofNullable(atomspaceStream)).run();
+            new QuestionToOpencogApp(inputStream, outputStream, errorOutputStream,
+                    Optional.ofNullable(atomspaceStream)).run();
         } catch (ParseException e) {
             HelpFormatter formatter = new HelpFormatter();
             formatter.printHelp("QuestionToOpencogApp", options);
@@ -93,6 +104,7 @@ public class QuestionToOpencogApp {
         } finally {
             closeStream(inputStream, System.in);
             closeStream(outputStream, System.out);
+            closeStream(errorOutputStream, System.err);
             closeStream(atomspaceStream, System.out);
         }
     }
@@ -123,11 +135,17 @@ public class QuestionToOpencogApp {
                         if (atomspaceWriter != null) {
                             extractFactForAtomspace(parsedRecord);
                         }
-                        printWriter.println(parsedRecord.getRecord().save());
+
+                        if (parsedRecord.relexFormula.isValid()) {
+                            printWriter.println(parsedRecord.getRecord().save());
+                        } else {
+                            errorPrintWriter.println(parsedRecord.getInvalidRecord());
+                        }
                     });
         } finally {
             linesStream.close();
             printWriter.flush();
+            errorPrintWriter.flush();
             if (atomspaceWriter != null) {
                 atomspaceWriter.flush();
             }
@@ -202,6 +220,31 @@ public class QuestionToOpencogApp {
         public RelexFormula getRelexFormula() {
             return relexFormula;
         }
+
+
+        public boolean isValid() {
+            return relexFormula.getNumSkippedWords() == 0 && relexFormula.getNumViolations() == 0;
+        }
+
+        public String getInvalidRecord() {
+            StringBuilder invalidRecord = new StringBuilder();
+            if (relexFormula.getNumViolations() > 0) {
+                invalidRecord.append("VIOLATION");
+            }
+            if (relexFormula.getNumSkippedWords() > 0) {
+                if (invalidRecord.length() != 0) {
+                    invalidRecord.append('|');
+                }
+                invalidRecord.append("SKIPPED");
+            }
+
+            invalidRecord.append("::");
+            invalidRecord.append(relexFormula.getRelexSentence().getOriginalSentence());
+
+            return invalidRecord.toString();
+
+        }
+
     }
     
     private String convertToOpencogScheme(ParsedQuestion parsedQuestion) {

--- a/experiments/opencog/question2atomese/src/main/java/org/opencog/vqa/QuestionToOpencogApp.java
+++ b/experiments/opencog/question2atomese/src/main/java/org/opencog/vqa/QuestionToOpencogApp.java
@@ -176,10 +176,11 @@ public class QuestionToOpencogApp {
 
     private ParsedQuestion parseQuestion(QuestionRecord record) {
         RelexFormula relexFormula = questionToOpencogConverter.parseQuestion(record.getQuestion());
-        
+
         QuestionRecord recordWithFormula = record.toBuilder()
                 .shortFormula(relexFormula.getFullFormula())
                 .fullFormula(relexFormula.getGroundedFormula())
+                .formulaInvalidKeys(relexFormula.getInvalidKeys())
                 .build();
         
         return new ParsedQuestion(recordWithFormula, relexFormula);

--- a/experiments/opencog/question2atomese/src/main/java/org/opencog/vqa/relex/RelexFormula.java
+++ b/experiments/opencog/question2atomese/src/main/java/org/opencog/vqa/relex/RelexFormula.java
@@ -9,7 +9,6 @@ import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Singular;
 import relex.ParsedSentence;
-import relex.feature.FeatureNode;
 
 public class RelexFormula {
 
@@ -41,25 +40,7 @@ public class RelexFormula {
     public String getGroundedFormula() {
         return predicates.stream().map(fn -> fn.toGroundedFormula()).collect(Collectors.joining(";"));
     }
-
-    public boolean isValid() {
-        return getNumSkippedWords() == 0 && getNumViolations() == 0;
-    }
-
-    public int getNumSkippedWords() {
-        return getMetaNums("num_skipped_words");
-    }
-
-    public int getNumViolations() {
-        return getMetaNums("num_violations");
-    }
-
-    private int getMetaNums(String propertyName) {
-        FeatureNode fn = relexSentence.getMetaData().get(propertyName);
-        if (fn == null) return 0;
-        return Integer.parseInt(fn.getValue());
-    }
-
+    
     @Override
     public String toString() {
         return getFullFormula();

--- a/experiments/opencog/question2atomese/src/main/java/org/opencog/vqa/relex/RelexFormula.java
+++ b/experiments/opencog/question2atomese/src/main/java/org/opencog/vqa/relex/RelexFormula.java
@@ -9,8 +9,12 @@ import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Singular;
 import relex.ParsedSentence;
+import relex.feature.FeatureNode;
 
 public class RelexFormula {
+
+    public static final String INVALID_KEY_SKIPPED = "SKIPPED";
+    public static final String INVALID_KEY_VIOLATION = "VIOLATION";
 
     private final List<RelexPredicate> predicates;
     private final ParsedSentence relexSentence;
@@ -40,7 +44,29 @@ public class RelexFormula {
     public String getGroundedFormula() {
         return predicates.stream().map(fn -> fn.toGroundedFormula()).collect(Collectors.joining(";"));
     }
-    
+
+    public String getInvalidKeys() {
+        return List.of(getNumSkippedWords() > 0 ? INVALID_KEY_SKIPPED : "",
+                getNumViolations() > 0 ? INVALID_KEY_VIOLATION : "")
+                .stream()
+                .filter(elem -> !elem.isEmpty())
+                .collect(Collectors.joining("|"));
+    }
+
+    private int getNumSkippedWords() {
+        return getMetaNums("num_skipped_words");
+    }
+
+    private int getNumViolations() {
+        return getMetaNums("num_violations");
+    }
+
+    private int getMetaNums(String propertyName) {
+        FeatureNode fn = relexSentence.getMetaData().get(propertyName);
+        if (fn == null) return 0;
+        return Integer.parseInt(fn.getValue());
+    }
+
     @Override
     public String toString() {
         return getFullFormula();

--- a/experiments/opencog/question2atomese/src/main/java/org/opencog/vqa/relex/RelexFormula.java
+++ b/experiments/opencog/question2atomese/src/main/java/org/opencog/vqa/relex/RelexFormula.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Singular;
 import relex.ParsedSentence;
+import relex.feature.FeatureNode;
 
 public class RelexFormula {
 
@@ -40,7 +41,25 @@ public class RelexFormula {
     public String getGroundedFormula() {
         return predicates.stream().map(fn -> fn.toGroundedFormula()).collect(Collectors.joining(";"));
     }
-    
+
+    public boolean isValid() {
+        return getNumSkippedWords() == 0 && getNumViolations() == 0;
+    }
+
+    public int getNumSkippedWords() {
+        return getMetaNums("num_skipped_words");
+    }
+
+    public int getNumViolations() {
+        return getMetaNums("num_violations");
+    }
+
+    private int getMetaNums(String propertyName) {
+        FeatureNode fn = relexSentence.getMetaData().get(propertyName);
+        if (fn == null) return 0;
+        return Integer.parseInt(fn.getValue());
+    }
+
     @Override
     public String toString() {
         return getFullFormula();

--- a/experiments/opencog/question2atomese/src/test/java/org/opencog/vqa/QuestionToOpencogAppTest.java
+++ b/experiments/opencog/question2atomese/src/test/java/org/opencog/vqa/QuestionToOpencogAppTest.java
@@ -16,7 +16,7 @@ public class QuestionToOpencogAppTest {
         InputStream inputStream = inputStreamFromString("458752002::other::What color is the players shirt?::458752::orange");
         ByteArrayOutputStream atomspaceStream = new ByteArrayOutputStream();
         
-        new QuestionToOpencogApp(inputStream, System.out, Optional.of(atomspaceStream)).run();
+        new QuestionToOpencogApp(inputStream, System.out, System.err, Optional.of(atomspaceStream)).run();
         
         assertEquals("(InheritanceLink (ConceptNode \"orange\") (ConceptNode \"color\"))\n", atomspaceStream.toString());
     }
@@ -26,7 +26,7 @@ public class QuestionToOpencogAppTest {
         InputStream inputStream = inputStreamFromString("579057010::other::What fruits are these?::579057::banana, orange and apples");
         ByteArrayOutputStream atomspaceStream = new ByteArrayOutputStream();
         
-        new QuestionToOpencogApp(inputStream, System.out, Optional.of(atomspaceStream)).run();
+        new QuestionToOpencogApp(inputStream, System.out, System.err, Optional.of(atomspaceStream)).run();
         
         assertEquals("(InheritanceLink (ConceptNode \"banana\") (ConceptNode \"fruit\"))\n"
                 + "(InheritanceLink (ConceptNode \"orange\") (ConceptNode \"fruit\"))\n"
@@ -38,7 +38,7 @@ public class QuestionToOpencogAppTest {
         InputStream inputStream = inputStreamFromString("418489000::other::What is this color of the shirt?::418489::red");
         ByteArrayOutputStream atomspaceStream = new ByteArrayOutputStream();
         
-        new QuestionToOpencogApp(inputStream, System.out, Optional.of(atomspaceStream)).run();
+        new QuestionToOpencogApp(inputStream, System.out, System.err, Optional.of(atomspaceStream)).run();
         
         assertEquals("", atomspaceStream.toString());
     }

--- a/experiments/opencog/question2atomese/src/test/java/org/opencog/vqa/QuestionToOpencogAppTest.java
+++ b/experiments/opencog/question2atomese/src/test/java/org/opencog/vqa/QuestionToOpencogAppTest.java
@@ -16,7 +16,7 @@ public class QuestionToOpencogAppTest {
         InputStream inputStream = inputStreamFromString("458752002::other::What color is the players shirt?::458752::orange");
         ByteArrayOutputStream atomspaceStream = new ByteArrayOutputStream();
         
-        new QuestionToOpencogApp(inputStream, System.out, System.err, Optional.of(atomspaceStream)).run();
+        new QuestionToOpencogApp(inputStream, System.out, Optional.of(atomspaceStream)).run();
         
         assertEquals("(InheritanceLink (ConceptNode \"orange\") (ConceptNode \"color\"))\n", atomspaceStream.toString());
     }
@@ -26,7 +26,7 @@ public class QuestionToOpencogAppTest {
         InputStream inputStream = inputStreamFromString("579057010::other::What fruits are these?::579057::banana, orange and apples");
         ByteArrayOutputStream atomspaceStream = new ByteArrayOutputStream();
         
-        new QuestionToOpencogApp(inputStream, System.out, System.err, Optional.of(atomspaceStream)).run();
+        new QuestionToOpencogApp(inputStream, System.out, Optional.of(atomspaceStream)).run();
         
         assertEquals("(InheritanceLink (ConceptNode \"banana\") (ConceptNode \"fruit\"))\n"
                 + "(InheritanceLink (ConceptNode \"orange\") (ConceptNode \"fruit\"))\n"
@@ -38,7 +38,7 @@ public class QuestionToOpencogAppTest {
         InputStream inputStream = inputStreamFromString("418489000::other::What is this color of the shirt?::418489::red");
         ByteArrayOutputStream atomspaceStream = new ByteArrayOutputStream();
         
-        new QuestionToOpencogApp(inputStream, System.out, System.err, Optional.of(atomspaceStream)).run();
+        new QuestionToOpencogApp(inputStream, System.out, Optional.of(atomspaceStream)).run();
         
         assertEquals("", atomspaceStream.toString());
     }

--- a/experiments/opencog/question2atomese/src/test/java/org/opencog/vqa/QuestionToOpencogAppTest.java
+++ b/experiments/opencog/question2atomese/src/test/java/org/opencog/vqa/QuestionToOpencogAppTest.java
@@ -43,6 +43,29 @@ public class QuestionToOpencogAppTest {
         assertEquals("", atomspaceStream.toString());
     }
 
+    @Test
+    public void test_ParseValidSentence() {
+        test_ParseSentence("196608003::yes/no::Is the laptop on?::196608::no::None::None",
+                "196608003::yes/no::Is the laptop on?::196608::no::_subj(A, B)::_subj(be_on, laptop)");
+    }
+
+    @Test
+    public void test_ParseInvalidSentence() {
+        test_ParseSentence("158335000::number::How many cakes on in her hand?::158335::2::None::None",
+                "158335000::number::How many cakes on in her hand?::158335::2::SKIPPED");
+    }
+
+    private void test_ParseSentence(String sentence, String parsedSentence) {
+        InputStream inputStream = inputStreamFromString(sentence);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        new QuestionToOpencogApp(inputStream, outputStream, Optional.empty()).run();
+
+        String record = outputStream.toString();
+        System.out.printf("record: %s%n", record);
+        assertEquals(parsedSentence, outputStream.toString().trim());
+    }
+
     private static ByteArrayInputStream inputStreamFromString(String string) {
         return new ByteArrayInputStream(string.getBytes());
     }


### PR DESCRIPTION
The fix add -e --error option which allows to filter out invalid questions (questions which are not parsed by LinkGrammar) to a separate error file.

