### PR TITLE
Add valueToPtrValue convertor as temporary workaround

### DIFF
--- a/experiments/opencog/opencog-neuralnet/cython/opencog/ptrvalue.pyx
+++ b/experiments/opencog/opencog-neuralnet/cython/opencog/ptrvalue.pyx
@@ -19,3 +19,6 @@ cdef void decref(void* obj):
 def PtrValue(obj):
     Py_INCREF(obj)
     return wrapPtrValue(createPtrValue(<void*>obj, decref))
+
+def valueToPtrValue(value):
+    return wrapPtrValue(<cValuePtr>((<Value>value).shared_ptr))

--- a/experiments/opencog/opencog-neuralnet/tests/cython/opencog/test_ptrvalue.py
+++ b/experiments/opencog/opencog-neuralnet/tests/cython/opencog/test_ptrvalue.py
@@ -2,7 +2,8 @@ import unittest
 
 from opencog.atomspace import AtomSpace
 from opencog.utilities import initialize_opencog, finalize_opencog
-from opencog.neuralnet import PtrValue
+from opencog.neuralnet import PtrValue, valueToPtrValue
+from opencog.type_constructors import ConceptNode
 
 class PtrValueTest(unittest.TestCase):
 
@@ -18,6 +19,17 @@ class PtrValueTest(unittest.TestCase):
         obj = TestObject("some object")
 
         value = PtrValue(obj)
+
+        ref = value.value()
+        self.assertEqual(ref.name, "some object")
+
+    def test_pass_value_via_atom(self):
+        obj = TestObject("some object")
+        container = ConceptNode("container")
+        key = ConceptNode("key")
+        container.set_value(key, PtrValue(obj))
+
+        value = valueToPtrValue(container.get_value(key))
 
         ref = value.value()
         self.assertEqual(ref.name, "some object")


### PR DESCRIPTION
Add valueToPtrValue convertor as temporary workaround for Atom.get_value() type conversion issue.