### PR TITLE
store tensors in Links

### DIFF
--- a/experiments/opencog/cog_module/example.py
+++ b/experiments/opencog/cog_module/example.py
@@ -145,7 +145,7 @@ bl = BindLink(
 
 print("bl2")
 print(bl)
-execute_atom(atomspace, bl)
+print(execute_atom(atomspace, bl))
 print(net1)
 print(net2)
 print(m1)

--- a/experiments/opencog/cog_module/module.py
+++ b/experiments/opencog/cog_module/module.py
@@ -90,7 +90,7 @@ class CogModule(torch.nn.Module):
         result = self.forward(*unpack_args(*args))
         atomspace = self.get_atomspace(args)
         # todo: check new atom is not in atomspace
-        # use atomspace as chache
+        # use atomspace as cache
         res_atom = ExecutionOutputLink(
                          GroundedSchemaNode("py:CogModule.callMethod"),
                          ListLink(self.atom,

--- a/experiments/opencog/cog_module/test.py
+++ b/experiments/opencog/cog_module/test.py
@@ -5,7 +5,6 @@ from opencog.atomspace import AtomSpace, types
 from opencog.utilities import initialize_opencog, finalize_opencog
 from opencog.type_constructors import *
 from module import CogModule, CogModel, InputModule
-from module import CogModule
 
 
 import __main__

--- a/experiments/opencog/cog_module/test.py
+++ b/experiments/opencog/cog_module/test.py
@@ -42,7 +42,7 @@ class TestBasic(unittest.TestCase):
         result = self.model.evaluate_atom(query)
         expected = colors.mean(dim=-1).mean(dim=-1) + colors.max()
         delta = 0.00000001
-        self.assertTrue(expected[GREEN] - result.mean < delta)
+        self.assertTrue(abs(expected[GREEN] - result.mean) < delta)
 
     def tearDown(self):
         self.atomspace = None

--- a/experiments/opencog/cog_module/test.py
+++ b/experiments/opencog/cog_module/test.py
@@ -1,0 +1,51 @@
+import unittest
+import torch
+
+from opencog.atomspace import AtomSpace, types
+from opencog.utilities import initialize_opencog, finalize_opencog
+from opencog.type_constructors import *
+from module import CogModule, CogModel, InputModule
+from module import CogModule
+
+
+import __main__
+__main__.CogModule = CogModule
+
+
+RED = 0
+GREEN = 1
+BLUE = 2
+
+
+class GreenPredicate(CogModule):
+
+    def forward(self, x):
+        """
+        extract green channel and shift it above zero
+        """
+        mean = x.mean(dim=-1).mean(dim=-1)
+        return mean[GREEN] + x.max()
+
+class TestBasic(unittest.TestCase):
+
+    def setUp(self):
+        self.atomspace = AtomSpace()
+        self.model = CogModel(self.atomspace)
+        initialize_opencog(self.atomspace)
+
+    def test_eval_link(self):
+        apple = ConceptNode('apple')
+        colors = torch.rand(3, 4, 4) - 0.5
+        inp = InputModule(apple, colors)
+        green = GreenPredicate(ConceptNode('green'))
+        query = green.evaluate(inp.execute())
+        result = self.model.evaluate_atom(query)
+        expected = colors.mean(dim=-1).mean(dim=-1) + colors.max()
+        delta = 0.00000001
+        self.assertTrue(expected[GREEN] - result.mean < delta)
+
+    def tearDown(self):
+        self.atomspace = None
+        self.model = None
+        finalize_opencog()
+


### PR DESCRIPTION
Get rid of temporary atoms to store intermediate tensors. Instead store tensors in ExecutionOutput and Evaluation links