### PR TITLE
return empty string from pattern matcher for no-answer

### DIFF
--- a/experiments/opencog/pattern_matcher_vqa/pattern_matcher_vqa.py
+++ b/experiments/opencog/pattern_matcher_vqa/pattern_matcher_vqa.py
@@ -439,7 +439,7 @@ class PatternMatcherVqaPipeline:
 
         results = self.sort_results(resultsData, a_extract_predicate=True)
         if not results:
-            return None, None, None
+            return '', None, None
         maxResult = results[0]
         return maxResult.get_predicate_name(), \
                maxResult.get_bounding_box_id(), \


### PR DESCRIPTION
This change is useful for vqa snet service. Empy string will be returned for questions when no answer is found. For example empty string will be returned if picture doesn't contain dog and the question is "What color is the dog?" 