### PR TITLE
quote result atoms in nested execution output links

### DIFF
--- a/experiments/opencog/cog_module/cognets/module.py
+++ b/experiments/opencog/cog_module/cognets/module.py
@@ -111,11 +111,11 @@ class CogModule(torch.nn.Module):
 
     def call_forward(self, args):
         args = args.out
-        res_atom = ExecutionOutputLink(
+        res_atom = QuoteLink(ExecutionOutputLink(
                          GroundedSchemaNode("py:CogModule.callMethod"),
                          ListLink(self.atom,
                                   ConceptNode("call_forward"),
-                                  ListLink(*args)))
+                                  ListLink(*args))))
         cached_value = get_value(res_atom)
         if cached_value is not None:
             return res_atom

--- a/experiments/opencog/cog_module/mnist.py
+++ b/experiments/opencog/cog_module/mnist.py
@@ -13,8 +13,8 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 from torchvision import datasets, transforms
-from module import CogModule, CogModel, get_value
-from module import InputModule, set_value
+from cognets import CogModule, CogModel, get_value
+from cognets import InputModule, set_value
 
 try:
     from opencog.utilities import tmp_atomspace


### PR DESCRIPTION
Adding QuotLink to avoid stack overflow

ExecutionOutputLink now checks if it got some executable link as the result. If so it runs it, leading to stack overflow in our case.